### PR TITLE
Add an error name to auth exceptions when the token is expired. Part …

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -170,8 +170,11 @@ PlexAPI.prototype._request = function _request(options) {
             // 401 unauthorized when authentication is required against the requested URL
             if (response.statusCode === 401) {
                 if (self.authenticator === undefined) {
-                    return reject(new Error('Plex Server denied request, you must provide a way to authenticate! ' +
-                        'Read more about plex-api authenticators on https://www.npmjs.com/package/plex-api#authenticators'));
+                    var authenticationError = new Error('Plex Server denied request, you must provide a way to authenticate! ' + 'Read more about plex-api authenticators on https://www.npmjs.com/package/plex-api#authenticators');
+                 	// If we have an auth token but receive a 401 we can assume the token as expired
+					if (self.authToken)
+						authenticationError.name = 'TokenExpiredError';
+					return reject(authenticationError);
                 }
 
                 return resolve(self._authenticate()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plex-api",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Simple wrapper for querying against HTTP API on the Plex Media Server",
   "main": "lib/api.js",
   "directories": {


### PR DESCRIPTION
I just added a single change to support the new `TokenExpiredError` as a part of https://github.com/plexinc/alexa-plex/issues/175.